### PR TITLE
Upgrade docker image to pulumi v3.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pulumi/pulumi:v2.21.0
+FROM pulumi/pulumi:v3.4.0
 
 COPY check /opt/resource/check
 COPY in /opt/resource/in


### PR DESCRIPTION
The Dockerfile of v0.2.0 is still pointing to Pulumi v2.x, though the release description says it should be v3 😉 
